### PR TITLE
Fixed bugs and made changes for undos and snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jstris-plus",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jstris-plus",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "dependencies": {
         "webpack": "^5.73.0",
         "zip-folder": "^1.0.0"

--- a/src/practiceFumen.js
+++ b/src/practiceFumen.js
@@ -53,28 +53,26 @@ const generateFumenMatrix = function () {
     return fieldStr
 }
 export const initPracticeFumen = () => {
-    const oldstartPractice = Game.prototype.restart;
+    const oldRestart = Game.prototype.restart;
     Game.prototype.restart = function () {
         const urlParams = new URLSearchParams(window.location.search);
         const snapshot = urlParams.get("snapshotPlus")
 
         if (this.pmode === 2 && snapshot != null) {
-            let val = oldstartPractice.apply(this, arguments)
+            let val = oldRestart.apply(this, arguments)
             let game = LZString.decompressFromEncodedURIComponent(snapshot)
             game = JSON.parse(game)
             console.log(game)
-            this.blockSeed = game.seed
-            this.blockRNG = alea(this.blockSeed)
-            this.RNG = alea(this.blockSeed)
-            this.initRandomizer(game.rnd)
-            this.generateQueue();
-            for (let i = 0; i <= game.placedBlocks; i++) {
-                this.activeBlock = this.getBlockFromQueue()
-            }
-            if (game.holdID != null) {
-                this.blockInHold = new Block(game.holdID)
-                this.activeBlock = this.getBlockFromQueue()
-            }
+
+            let heldBlock = game.holdID == null ? null : new Block(game.holdID);
+            this.loadSeedAndPieces(
+                game.seed,
+                game.rnd,
+                game.placedBlocks,
+                new Block(game.activeBlockID),
+                heldBlock
+            )
+
             this.matrix = clone(game.matrix)
             this.deadline = clone(game.deadline)
             this.setCurrentPieceToDefaultPos();
@@ -85,7 +83,7 @@ export const initPracticeFumen = () => {
         } else {
             this.fumenPages = null
             if (this.pmode === 2) this.fumenPages = []
-            return oldstartPractice.apply(this, arguments);
+            return oldRestart.apply(this, arguments);
 
         }
 
@@ -301,13 +299,14 @@ export const initReplayerSnapshot = () => {
         let deadline = clone(this.deadline)
         let placedBlocks = this.placedBlocks
         let seed = this.r.c.seed
+        let activeBlockID = this.activeBlock.id;
         let holdID = null
         if (this.blockInHold) {
             holdID = this.blockInHold.id
         }
         let rnd = this.R.rnd
         return LZString.compressToEncodedURIComponent(JSON.stringify({
-            matrix, deadline, placedBlocks, seed, holdID, rnd
+            matrix, deadline, placedBlocks, seed, activeBlockID, holdID, rnd
         }))
     }
 }


### PR DESCRIPTION
Several minor changes and fixes to undoing / loading snapshots:
- Fixed a bug where undoing after loading a snapshot would break the game.
- Fixed a bug where loading a snapshot would get the wrong active piece if taken right after a hold.
- Fixed a bug where combos weren't correctly saved and loaded for undos
- Setting the rng seed is a bit more efficient now. No longer shifts around the queue for every throw-away piece generated.
- Undo now triggers on keydown, instead of keyup (which also allows spamming undo by holding the key)
- Player can now always hold after an undo, even if they just held previously
- Refactored undos and snapshots